### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for all text files
+* text=auto eol=lf


### PR DESCRIPTION
Fixes CRLF/LF conflicts when editing via Windows path.